### PR TITLE
Extend constraints and response blocks

### DIFF
--- a/Hook-Examples.md
+++ b/Hook-Examples.md
@@ -5,10 +5,14 @@ This page is still work in progress. Feel free to contribute!
 ```hcl
 server {
   hook "webhook" {
-    constraints = [
-      "${"refs/heads/master" == payload("ref")}",
-      "${sha256(payload, "mysecret") == header("X-Signature")}",
-    ]
+    constraints {
+      all {
+        expressions = [
+          "${"refs/heads/master" == payload("ref")}",
+          "${sha256(payload, "mysecret") == header("X-Signature")}",
+        ]
+      }
+    }
     task {
       workdir = "/home/adnan/go"
 
@@ -30,9 +34,13 @@ Bitbucket does not pass any secrets back to the webhook.  [Per their documentati
 ```hcl
 server {
   hook "webhook" {
-    constraints = [
-      "${request.RemoteAddr.WithinCIDR("104.192.143.0/24")}",
-    ]
+    constraints {
+      all {
+        expressions = [
+          "${request.RemoteAddr.WithinCIDR("104.192.143.0/24")}",
+        ]
+      }
+    }
     task {
       workdir = "/home/adnan/go"
 
@@ -54,9 +62,13 @@ Values in the request body can be accessed in the command or to the match rule b
 ```hcl
 server {
   hook "redeploy-webhook" {
-    constraints = [
-      "${header("X-Gitlab-Token") == "<YOUR-GENERATED-TOKEN>"}",
-    ]
+    constraints {
+      all {
+        expressions = [
+          "${header("X-Gitlab-Token") == "<YOUR-GENERATED-TOKEN>"}",
+        ]
+      }
+    }
     task {
       workdir = "/home/adnan/go"
 
@@ -74,10 +86,14 @@ server {
 ```hcl
 server {
   hook "webhook" {
-    constraints = [
-      "${"refs/heads/master" == payload("ref")}",
-      "${sha256(payload, "mysecret") == header("X-Gogs-Signature")}",
-    ]
+    constraints {
+      all {
+        expressions = [
+          "${"refs/heads/master" == payload("ref")}",
+          "${sha256(payload, "mysecret") == header("X-Gogs-Signature")}",
+        ]
+      }
+    }
     task {
       workdir = "/home/adnan/go"
 
@@ -97,10 +113,14 @@ server {
 ```hcl
 server {
   hook "webhook" {
-    constraints = [
-      "${"refs/heads/master" == payload("ref")}",
-      "${"mysecret" == payload("secret")}",
-    ]
+    constraints {
+      all {
+        expressions = [
+          "${"refs/heads/master" == payload("ref")}",
+          "${"mysecret" == payload("secret")}",
+        ]
+      }
+    }
     task {
       workdir = "/home/adnan/go"
 
@@ -120,9 +140,13 @@ server {
 ```hcl
 server {
   hook "redeploy-webhook" {
-    constraints = [
-      "${payload("token") == "<YOUR-GENERATED-TOKEN>"}",
-    ]
+    constraints {
+      all {
+        expressions = [
+          "${payload("token") == "<YOUR-GENERATED-TOKEN>"}",
+        ]
+      }
+    }
     task {
       workdir = "/home/adnan/go"
 
@@ -132,7 +156,9 @@ server {
       ]
     }
     response {
-      body = "${result.error ? result.CombinedOutput : "Executing redeploy script"}"
+      success {
+        body = "Executing redeploy script"
+      }
     }
   }
 }
@@ -148,14 +174,20 @@ __Not recommended in production due to low security__
 ```hcl
 server {
   hook "simple-one" {
-    constraints = [
-      "${parameter("token") == "42"}",
-    ]
+    constraints {
+      all {
+        expressions = [
+          "${parameter("token") == "42"}",
+        ]
+      }
+    }
     task {
       cmd = ["/path/to/command.sh"]
     }
     response {
-      body = "${result.error ? result.CombinedOutput : "Executing simple webhook.."}"
+      success {
+        body = "Executing simple webhook..."
+      }
     }
   }
 }
@@ -185,7 +217,9 @@ server {
       }
     }
     response {
-      body = "${result.CombinedOutput}"
+      success {
+        body = "${result.CombinedOutput}"
+      }
     }
   }
 }
@@ -225,10 +259,14 @@ In order to leverage the Signing Key for addtional authentication/security you m
 ```hcl
 server {
   hook "redeploy-webhook" {
-    constraints = [
-      "${since(header("Date")) <= duration("300s")}",
-      "${sha1(payload, "Scalr-provided signing key") == header("X-Signature")}",
-    ]
+    constraints {
+      all {
+        expressions = [
+          "${since(header("Date")) <= duration("300s")}",
+          "${sha1(payload, "Scalr-provided signing key") == header("X-Signature")}",
+        ]
+      }
+    }
     task {
       workdir = "/home/adnan/go"
 
@@ -240,7 +278,9 @@ server {
       }
     }
     response {
-      body = "${result.CombinedOutput}"
+      success {
+        body = "${result.CombinedOutput}"
+      }
     }
   }
 }
@@ -252,10 +292,14 @@ Travis sends webhooks as `payload=<JSON_STRING>`, so the payload needs to be par
 ```hcl
 server {
   hook "deploy" {
-    constraints = [
-      "${payload("payload.state") == "passed"}",
-      "${payload("payload.branch") == "master"}",
-    ]
+    constraints {
+      all {
+        expressions = [
+          "${payload("payload.state") == "passed"}",
+          "${payload("payload.branch") == "master"}",
+        ]
+      }
+    }
     request {
       json_parameters = ["payload"]
     }

--- a/config/hook.go
+++ b/config/hook.go
@@ -29,7 +29,7 @@ type Hook struct {
 	PreExecConfig hcl.Body `hcl:",remain"`
 
 	// Request     *Request
-	Constraints *[]string
+	Constraints *Constraints
 	Task        Task
 	Response    *Response
 }
@@ -40,9 +40,36 @@ type Request struct {
 }
 
 type PreExecConfig struct {
-	Constraints    *[]string `hcl:"constraints"`
-	Task           Task      `hcl:"task,block"`
-	PostExecConfig hcl.Body  `hcl:",remain"`
+	Constraints    *Constraints `hcl:"constraints,block"`
+	Task           Task         `hcl:"task,block"`
+	PostExecConfig hcl.Body     `hcl:",remain"`
+}
+
+type Constraints struct {
+	All  *All  `hcl:"all,block"`
+	Any  *Any  `hcl:"any,block"`
+	None *None `hcl:"none,block"`
+}
+
+type All struct {
+	Expressions []string `hcl:"expressions"`
+	All         *All     `hcl:"all,block"`
+	Any         *Any     `hcl:"any,block"`
+	None        *None    `hcl:"none,block"`
+}
+
+type Any struct {
+	Expressions []string `hcl:"expressions"`
+	All         *All     `hcl:"all,block"`
+	Any         *Any     `hcl:"any,block"`
+	None        *None    `hcl:"none,block"`
+}
+
+type None struct {
+	Expressions []string `hcl:"expressions"`
+	All         *All     `hcl:"all,block"`
+	Any         *Any     `hcl:"any,block"`
+	None        *None    `hcl:"none,block"`
 }
 
 type Task struct {
@@ -76,11 +103,30 @@ type PostExecConfig struct {
 }
 
 type Response struct {
-	SuccessHttpResponseCode             *int               `hcl:"success_response_code"`
-	TriggerRuleMismatchHttpResponseCode *int               `hcl:"failed_constraints_response_code"`
-	ContentType                         *string            `hcl:"content_type"`
-	Body                                *string            `hcl:"body"`
-	Headers                             *map[string]string `hcl:"headers"`
+	ResponseSuccess     *ResponseSuccess     `hcl:"success,block"`
+	ResponseError       *ResponseError       `hcl:"error,block"`
+	ResponseUnsatisfied *ResponseUnsatisfied `hcl:"unsatisfied_constraints,block"`
+}
+
+type ResponseError struct {
+	StatusCode  *int               `hcl:"status_code"`
+	ContentType *string            `hcl:"content_type"`
+	Body        *string            `hcl:"body"`
+	Headers     *map[string]string `hcl:"headers"`
+}
+
+type ResponseSuccess struct {
+	StatusCode  *int               `hcl:"status_code"`
+	ContentType *string            `hcl:"content_type"`
+	Body        *string            `hcl:"body"`
+	Headers     *map[string]string `hcl:"headers"`
+}
+
+type ResponseUnsatisfied struct {
+	StatusCode  *int               `hcl:"status_code"`
+	ContentType *string            `hcl:"content_type"`
+	Body        *string            `hcl:"body"`
+	Headers     *map[string]string `hcl:"headers"`
 }
 
 func (s Server) Dump() {
@@ -109,7 +155,16 @@ func (s Server) Dump() {
 		}
 
 		if h.Constraints != nil {
-			fmt.Println("    Constraints:", *h.Constraints)
+			fmt.Println("    Constraints:")
+			if h.Constraints.All != nil {
+				fmt.Println("      All:", *h.Constraints.All)
+			}
+			if h.Constraints.Any != nil {
+				fmt.Println("      Any:", *h.Constraints.Any)
+			}
+			if h.Constraints.None != nil {
+				fmt.Println("      None:", *h.Constraints.None)
+			}
 		}
 
 		fmt.Println("    Task:")
@@ -129,20 +184,50 @@ func (s Server) Dump() {
 
 		if h.Response != nil {
 			fmt.Println("    Response:")
-			if h.Response.SuccessHttpResponseCode != nil {
-				fmt.Println("      SuccessHttpResponseCode:", *h.Response.SuccessHttpResponseCode)
+			if h.Response.ResponseSuccess != nil {
+				fmt.Println("      Success:")
+				if h.Response.ResponseSuccess.StatusCode != nil {
+					fmt.Println("        StatusCode:", *h.Response.ResponseSuccess.StatusCode)
+				}
+				if h.Response.ResponseSuccess.ContentType != nil {
+					fmt.Println("        ContentType:", *h.Response.ResponseSuccess.ContentType)
+				}
+				if h.Response.ResponseSuccess.Body != nil {
+					fmt.Println("        Body:", *h.Response.ResponseSuccess.Body)
+				}
+				if h.Response.ResponseSuccess.Headers != nil {
+					fmt.Println("        Headers:", *h.Response.ResponseSuccess.Headers)
+				}
 			}
-			if h.Response.TriggerRuleMismatchHttpResponseCode != nil {
-				fmt.Println("      TriggerRuleMismatchHttpResponseCode:", *h.Response.TriggerRuleMismatchHttpResponseCode)
+			if h.Response.ResponseError != nil {
+				fmt.Println("      Error:")
+				if h.Response.ResponseError.StatusCode != nil {
+					fmt.Println("        StatusCode:", *h.Response.ResponseError.StatusCode)
+				}
+				if h.Response.ResponseError.ContentType != nil {
+					fmt.Println("        ContentType:", *h.Response.ResponseError.ContentType)
+				}
+				if h.Response.ResponseError.Body != nil {
+					fmt.Println("        Body:", *h.Response.ResponseError.Body)
+				}
+				if h.Response.ResponseError.Headers != nil {
+					fmt.Println("        Headers:", *h.Response.ResponseError.Headers)
+				}
 			}
-			if h.Response.ContentType != nil {
-				fmt.Println("      ContentType:", *h.Response.ContentType)
-			}
-			if h.Response.Body != nil {
-				fmt.Println("      Body:", *h.Response.Body)
-			}
-			if h.Response.Headers != nil {
-				fmt.Println("      Headers:", *h.Response.Headers)
+			if h.Response.ResponseUnsatisfied != nil {
+				fmt.Println("      Unsatisfied:")
+				if h.Response.ResponseUnsatisfied.StatusCode != nil {
+					fmt.Println("        StatusCode:", *h.Response.ResponseUnsatisfied.StatusCode)
+				}
+				if h.Response.ResponseUnsatisfied.ContentType != nil {
+					fmt.Println("        ContentType:", *h.Response.ResponseUnsatisfied.ContentType)
+				}
+				if h.Response.ResponseUnsatisfied.Body != nil {
+					fmt.Println("        Body:", *h.Response.ResponseUnsatisfied.Body)
+				}
+				if h.Response.ResponseUnsatisfied.Headers != nil {
+					fmt.Println("        Headers:", *h.Response.ResponseUnsatisfied.Headers)
+				}
 			}
 		}
 		fmt.Println("")

--- a/config3.hcl
+++ b/config3.hcl
@@ -67,6 +67,16 @@ server {
           }
 
           success {
+            status_code = 222
+            headers = { // response-headers
+                name = "${result.pid}",
+            }
+            content_type = "application/json"
+            body = "${result.CombinedOutput}" // include-command-output-in-response
+          }
+
+          error {
+            status_code = 555
             headers = { // response-headers
                 name = "${result.pid}",
             }

--- a/config3.hcl
+++ b/config3.hcl
@@ -4,14 +4,25 @@ server {
     secure = false
 
     hook "PREFIX/webhook" {
-        constraints = [ // trigger-rule
-            "${since(header("Date")) <= duration("10m")}",
-            "${match("^refs/[^/]+/master", payload("ref")) && sha256(payload, "secret") == header("X-Signature")}",
-        ]
+        constraints { // trigger-rule
+          all {
+            expressions = [
+              "${since(header("Date")) <= duration("10m")}",
+              "${match("^refs/[^/]+/master", payload("ref")) && sha256(payload, "secret") == header("X-Signature")}",
+            ]
+            any {
+              expressions = [
+                "${since(header("Date")) <= duration("10m")}",
+                "${match("^refs/[^/]+/master", payload("ref")) && sha256(payload, "secret") == header("X-Signature")}",
+              ]
+            }
+          }
+        }
 
         task {
             // execute-command & pass-arguments-to-command
             cmd = [
+              // "/issue217/vol-key-${payload("newVolume") > payload("previousVolume") ? "up" : "down"}.sh",
               "/home/adnon/redeploy-go-webhook.sh",
               "${payload("a")}",
               "${payload("head_commit.id")}",
@@ -51,24 +62,17 @@ server {
         }
 
         response {
-          success_response_code = 200
-          failed_constraints_response_code = 401
-
-          content_type = "application/json"
-
-          headers = { // response-headers
-              // name = "${result.PID}",
-              name = "${result.pid}",
+          unsatisfied_constraints {
+            status_code = 444
           }
 
-          // Is this too complex for the average user?  Should this be a block?
-          //   body {
-          //     success = "${result.CombinedOutput}",
-          //     error   = "${result.error}",
-          //     failed  = "contraints not satisfied",
-          //   }
-          body = "${result.error ? result.CombinedOutput : "success"}" // simple response-message & include-command-output-in-response-on-error
-          // body = "${result.CombinedOutput}" // include-command-output-in-response
+          success {
+            headers = { // response-headers
+                name = "${result.pid}",
+            }
+            content_type = "application/json"
+            body = "${result.CombinedOutput}" // include-command-output-in-response
+          }
         }
     }
 }


### PR DESCRIPTION
Extend `constraints` block to allow for `all`, `any`, and `none`
sub-blocks with a named `expressions` attribute within those
sub-blocks.

Extend `response` block to have separate sub-blocks for `error`,
`success`, and `unsatisfied_constraints`.

See initial discussion in #1.