### PR TITLE
PoC for multiple signature scenario

### DIFF
--- a/config/context.go
+++ b/config/context.go
@@ -6,7 +6,9 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
+	"log"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/hcl/v2"
@@ -27,6 +29,9 @@ var (
 func init() {
 	funcMap = map[string]function.Function{
 		"base64decode": base64decodeFunc(),
+		"concat":       concatFunc(),
+		"contains":     containsFunc(),
+		"debug":        debugFunc(),
 		"duration":     durationFunc(),
 		"format":       stdlib.FormatFunc,
 		"header":       headerFunc(),
@@ -196,6 +201,50 @@ func matchFunc() function.Function {
 	})
 }
 
+func concatFunc() function.Function {
+	return function.New(&function.Spec{
+		Params: []function.Parameter{
+			{
+				Name: "s1",
+				Type: cty.String,
+			},
+			{
+				Name: "s2",
+				Type: cty.String,
+			},
+		},
+		Type: function.StaticReturnType(cty.String),
+		Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
+			s1 := args[0].AsString()
+			s2 := args[1].AsString()
+
+			return cty.StringVal(s1 + s2), nil
+		},
+	})
+}
+
+func containsFunc() function.Function {
+	return function.New(&function.Spec{
+		Params: []function.Parameter{
+			{
+				Name: "s",
+				Type: cty.String,
+			},
+			{
+				Name: "substr",
+				Type: cty.String,
+			},
+		},
+		Type: function.StaticReturnType(cty.Bool),
+		Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
+			s := args[0].AsString()
+			substr := args[1].AsString()
+
+			return cty.BoolVal(strings.Contains(s, substr)), nil
+		},
+	})
+}
+
 func durationFunc() function.Function {
 	return function.New(&function.Spec{
 		Params: []function.Parameter{
@@ -257,6 +306,25 @@ func base64decodeFunc() function.Function {
 			}
 
 			return stdlib.BytesVal(data), err
+		},
+	})
+}
+
+func debugFunc() function.Function {
+	return function.New(&function.Spec{
+		Params: []function.Parameter{
+			{
+				Name: "v",
+				Type: cty.String,
+			},
+		},
+		Type: function.StaticReturnType(cty.Bool),
+		Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
+			v := args[0].AsString()
+
+			log.Print(v)
+
+			return cty.BoolVal(true), nil
 		},
 	})
 }

--- a/config/hook.go
+++ b/config/hook.go
@@ -58,6 +58,10 @@ type All struct {
 	None        *None    `hcl:"none,block"`
 }
 
+func (a *All) String() string {
+	return fmt.Sprintf("All: {Expressions: %v, %v, %v, %v}", a.Expressions, a.All, a.Any, a.None)
+}
+
 type Any struct {
 	Expressions []string `hcl:"expressions"`
 	All         *All     `hcl:"all,block"`
@@ -65,11 +69,19 @@ type Any struct {
 	None        *None    `hcl:"none,block"`
 }
 
+func (a *Any) String() string {
+	return fmt.Sprintf("All: {Expressions: %v, %v, %v, %v}", a.Expressions, a.All, a.Any, a.None)
+}
+
 type None struct {
 	Expressions []string `hcl:"expressions"`
 	All         *All     `hcl:"all,block"`
 	Any         *Any     `hcl:"any,block"`
 	None        *None    `hcl:"none,block"`
+}
+
+func (n *None) String() string {
+	return fmt.Sprintf("None: {Expressions: %v, %v, %v, %v}", n.Expressions, n.All, n.Any, n.None)
 }
 
 type Task struct {
@@ -155,16 +167,7 @@ func (s Server) Dump() {
 		}
 
 		if h.Constraints != nil {
-			fmt.Println("    Constraints:")
-			if h.Constraints.All != nil {
-				fmt.Println("      All:", *h.Constraints.All)
-			}
-			if h.Constraints.Any != nil {
-				fmt.Println("      Any:", *h.Constraints.Any)
-			}
-			if h.Constraints.None != nil {
-				fmt.Println("      None:", *h.Constraints.None)
-			}
+			fmt.Println("    Constraints:", *h.Constraints)
 		}
 
 		fmt.Println("    Task:")

--- a/config3.hcl
+++ b/config3.hcl
@@ -12,8 +12,12 @@ server {
             ]
             any {
               expressions = [
-                "${since(header("Date")) <= duration("10m")}",
-                "${match("^refs/[^/]+/master", payload("ref")) && sha256(payload, "secret") == header("X-Signature")}",
+                // https://github.com/adnanh/webhook/pull/355
+                "${contains(header("X-Coral-Signature"), concat("sha1=", sha1(payload, "secret")))}",
+                "${contains(header("X-Coral-Signature"), concat("sha256=", sha256(payload, "secret")))}",
+
+                "${debug(concat("sha1=", sha1(payload, "secret")))}",
+                "${debug(concat("sha256=", sha256(payload, "secret")))}",
               ]
             }
           }

--- a/main.go
+++ b/main.go
@@ -59,7 +59,8 @@ func main() {
 		"ref": "refs/heads/master",
 	}
 	config.Headers = map[string]string{
-		"X-Signature": "f417af3a21bd70379b5796d5f013915e7029f62c580fb0f500f59a35a6f04c89",
+		"X-Signature":       "f417af3a21bd70379b5796d5f013915e7029f62c580fb0f500f59a35a6f04c89",
+		"X-Coral-Signature": "sha1=b17e04cbb22afa8ffbff8796fc1894ed27badd9e,sha256=f417af3a21bd70379b5796d5f013915e7029f62c580fb0f500f59a35a6f04c89",
 		//"Date":        "Fri, 20 Sep 2019 14:09:11 GMT",
 	}
 	config.Params = map[string]string{}


### PR DESCRIPTION
Add `concat`, `contains`, and `debug` template functions.  Update test
configuration for multiple signature scenario.

The cty stdlib has a `concat` function, but it's for sequences, not
strings.

The `debug` function is just a proof-of-concept. I wanted to see if it
would work, and it does.